### PR TITLE
added filtered earn

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
             <li><p class='navbar-text statAvg'></p></li>
             <li><p class='navbar-text statStart'></p></li>
             <li><p class='navbar-text statRecent'></p></li>
+            <li><p class='navbar-text statFilteredEarn'></p></li>
           </ul>
 
         </div><!--/.nav-collapse -->

--- a/js/main.js
+++ b/js/main.js
@@ -79,6 +79,18 @@ function cleanStatsProjects() {
 var userList = new List('reviews', options, '');
 
 userList.on('updated', handleHover);
+userList.on('updated', updateFilteredEarn);
+
+/**
+ * updates .statFilteredEarn with the sum of matching projects
+ */
+function updateFilteredEarn() {
+  var sum = 0;
+  userList.matchingItems.forEach(function(item) {
+    sum += Number(item._values.price.substring(1));
+  });
+  $('.statFilteredEarn').html('Filtered sum: ' + numToMoney(sum));
+}
 
 function updateStats() {
   var spnSt = '<span class="text-success">';


### PR DESCRIPTION
Shows the sum of the filtered projects at the end of the header.
Usecase: Check the total earnings from a month, search for that month, i.e.: "2016-02"
